### PR TITLE
Fix: Correción botón logout

### DIFF
--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -29,7 +29,7 @@ const Header = () => {
                 <img src={cartIcon} className='cart-icon' onClick={() => onButtonClick('/')} />
                 {!isLoggedIn && <Button type={BUTTON_TYPES.HEADER} text='Iniciar sesión' path='/login' />}
                 {!isLoggedIn && <Button type={BUTTON_TYPES.HEADER} text='Registrarse' path='/register' />}
-                {isLoggedIn && <Button type={BUTTON_TYPES.HEADER} text='Cerrar sesión' path='logout' />}
+                {isLoggedIn && <Button type={BUTTON_TYPES.HEADER} text='Cerrar sesión' path='/logout' />}
                 {isLoggedIn && <Button type={BUTTON_TYPES.HEADER} text='Vender' path='/products/add-product' />}
 
             </div>


### PR DESCRIPTION
## Corregido el error por el cuál no se podía cerrar sesión fuera de la pantalla principal #120 

### Descripción

Había un error debido a que, a la hora de hacer el logout desde una pantalla distinta a la de inicio, no se realizaba correctamente porque la ruta estaba guardada como relativa en vez de absoluta. 

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [x] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.
