### PR TITLE
Feat: Listados de productos y artistas

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import 'react-chat-elements/dist/main.css';
 
 import OrderDetails from "./components/OrderDetails.jsx";
 import OrderCancelled from "./components/OrderCancelled.jsx";
+import DesignsPage from './pages/DesignsPage.jsx';
 
 function App() {
   const cartLocalStorage = JSON.parse(localStorage.getItem("cart") || "[]")
@@ -53,6 +54,7 @@ function App() {
           cart={cart}
           setCart={setCart}
         />} />
+        <Route path="/designs" element={<DesignsPage />} />
         <Route path="/designs/my-design" element={<CustomDesign />} />
         <Route path="/designs/details/:id" element={<CustomDesignDetails />} />
         <Route path="/designs/cancelled" element={<CustonDesignCancelled />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,9 @@ import 'react-chat-elements/dist/main.css';
 import OrderDetails from "./components/OrderDetails.jsx";
 import OrderCancelled from "./components/OrderCancelled.jsx";
 import DesignsPage from './pages/DesignsPage.jsx';
+import PiecesPage from './pages/PiecesPage.jsx';
+import PrintersPage from './pages/PrintersPage.jsx';
+import MaterialsPage from './pages/MaterialsPage.jsx';
 
 function App() {
   const cartLocalStorage = JSON.parse(localStorage.getItem("cart") || "[]")
@@ -58,6 +61,9 @@ function App() {
         <Route path="/designs/my-design" element={<CustomDesign />} />
         <Route path="/designs/details/:id" element={<CustomDesignDetails />} />
         <Route path="/designs/cancelled" element={<CustonDesignCancelled />} />
+        <Route path="/pieces" element={<PiecesPage />} />
+        <Route path="/printers" element={<PrintersPage />} />
+        <Route path="/materials" element={<MaterialsPage />} />
         <Route path="/register" element={<RegisterFormPage />} />
         <Route path="/login" element={<LoginFormPage />} />
         <Route path="/user-details/:id" element={<UserDetail />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import DesignsPage from './pages/DesignsPage.jsx';
 import PiecesPage from './pages/PiecesPage.jsx';
 import PrintersPage from './pages/PrintersPage.jsx';
 import MaterialsPage from './pages/MaterialsPage.jsx';
+import ArtistsPage from './pages/ArtistsPage.jsx';
 
 function App() {
   const cartLocalStorage = JSON.parse(localStorage.getItem("cart") || "[]")
@@ -64,6 +65,7 @@ function App() {
         <Route path="/pieces" element={<PiecesPage />} />
         <Route path="/printers" element={<PrintersPage />} />
         <Route path="/materials" element={<MaterialsPage />} />
+        <Route path="/artists" element={<ArtistsPage />} />
         <Route path="/register" element={<RegisterFormPage />} />
         <Route path="/login" element={<LoginFormPage />} />
         <Route path="/user-details/:id" element={<UserDetail />} />

--- a/frontend/src/components/ArtistsGrid/ArtistsGrid.css
+++ b/frontend/src/components/ArtistsGrid/ArtistsGrid.css
@@ -9,6 +9,32 @@
     justify-content: space-around;
 }
 
+.unlimited-gr {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+    margin: 3em 10em !important;
+}
+
+.artists-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+}
+
+.artists-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.last {
+    display: flex;
+    flex-direction: row;
+    gap: 1.25em;
+    align-self: flex-start;
+}
+
 @media (max-width: 1024px) {
 
     .grid {

--- a/frontend/src/components/ArtistsGrid/ArtistsGrid.jsx
+++ b/frontend/src/components/ArtistsGrid/ArtistsGrid.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import './ArtistsGrid.css'
 import Artist from '../Artist/Artist';
+import Text, { TEXT_TYPES } from '../Text/Text';
 
 const backend = JSON.stringify(import.meta.env.VITE_APP_BACKEND);
 const frontend = JSON.stringify(import.meta.env.VITE_APP_FRONTEND);
@@ -35,6 +36,25 @@ const ArtistsGrid = (consts) => {
         }
     }
 
+    const groupArtists = async () => {
+        try {
+            const artists = await getAllArtists();
+
+            const groupsOfArtists = artists.reduce((acc, artist, index) => {
+                const groupIndex = Math.floor(index / 5);
+                if (!acc[groupIndex]) {
+                    acc[groupIndex] = [];
+                }
+                acc[groupIndex].push(artist);
+                return acc;
+            }, []);
+
+            return groupsOfArtists;
+        } catch (error) {
+            console.error('Error al obtener y agrupar los artistas: ', error);
+        }
+    }
+
     const [artists, setArtists] = useState([]);
 
     useEffect(() => {
@@ -47,7 +67,8 @@ const ArtistsGrid = (consts) => {
                 if (gridType === GRID_TYPES.MAIN_PAGE) {
                     setArtists(res.slice(0, 5));
                 } else {
-                    setArtists(res);
+                    const groupsOfArtists = await groupArtists();
+                    setArtists(groupsOfArtists);
                 }
             }
         }
@@ -57,11 +78,26 @@ const ArtistsGrid = (consts) => {
 
     return (
         <div className={getGridClass()}>
-            {artists.map(artist => (
-                <div key={artist.id}>
-                    <Artist username={artist.username} pathImage='' pathDetails={artist.id} />
+            {gridType === GRID_TYPES.UNLIMITED ? (
+                <>
+                <Text type={TEXT_TYPES.TITLE_BOLD} text='Artistas' />
+                <div className='artists-container'>
+                    {artists.map((group, groupIndex) => (
+                        <div key={groupIndex} className={`artists-row ${group.length < 5 ? 'last' : ''}`}>
+                            {group.map((artist) => (
+                                <Artist username={artist.username} pathImage='' pathDetails={artist.id} />
+                            ))}
+                        </div>
+                    ))}
                 </div>
-            ))}
+            </>
+            ) : (
+                artists.map(artist => (
+                    <div key={artist.id}>
+                        <Artist username={artist.username} pathImage='' pathDetails={artist.id} />
+                    </div>
+                ))
+            )}
         </div>
     )
 }

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -14,7 +14,7 @@ const Navbar = () => {
                 <li onClick={() => onButtonClick('/pieces')}>Piezas</li>
                 <li onClick={() => onButtonClick('/printers')}>Impresoras</li>
                 <li onClick={() => onButtonClick('/materials')}>Materiales</li>
-                <li onClick={() => onButtonClick('/')}>Artistas</li>
+                <li onClick={() => onButtonClick('/artists')}>Artistas</li>
                 <li onClick={() => onButtonClick('/')}>Comunidad</li>
             </ul>
         </div>

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -10,7 +10,7 @@ const Navbar = () => {
     return (
         <div className='navbar'>
             <ul>
-                <li onClick={() => onButtonClick('/')}>Diseños</li>
+                <li onClick={() => onButtonClick('/designs')}>Diseños</li>
                 <li onClick={() => onButtonClick('/')}>Piezas</li>
                 <li onClick={() => onButtonClick('/')}>Impresoras</li>
                 <li onClick={() => onButtonClick('/')}>Materiales</li>

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -11,9 +11,9 @@ const Navbar = () => {
         <div className='navbar'>
             <ul>
                 <li onClick={() => onButtonClick('/designs')}>Diseños</li>
-                <li onClick={() => onButtonClick('/')}>Piezas</li>
-                <li onClick={() => onButtonClick('/')}>Impresoras</li>
-                <li onClick={() => onButtonClick('/')}>Materiales</li>
+                <li onClick={() => onButtonClick('/pieces')}>Piezas</li>
+                <li onClick={() => onButtonClick('/printers')}>Impresoras</li>
+                <li onClick={() => onButtonClick('/materials')}>Materiales</li>
                 <li onClick={() => onButtonClick('/')}>Artistas</li>
                 <li onClick={() => onButtonClick('/')}>Comunidad</li>
             </ul>

--- a/frontend/src/components/ProductsGrid/ProductsGrid.css
+++ b/frontend/src/components/ProductsGrid/ProductsGrid.css
@@ -29,6 +29,9 @@
 }
 
 .last {
+    display: flex;
+    flex-direction: row;
+    gap: 1.25em;
     align-self: flex-start;
 }
 

--- a/frontend/src/components/ProductsGrid/ProductsGrid.css
+++ b/frontend/src/components/ProductsGrid/ProductsGrid.css
@@ -9,6 +9,29 @@
     justify-content: space-around;
 }
 
+.unlimited-gr {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+    margin: 3em 10em !important;
+}
+
+.products-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+}
+
+.products-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.last {
+    align-self: flex-start;
+}
+
 @media (max-width: 1024px) {
 
     .grid {

--- a/frontend/src/components/ProductsGrid/ProductsGrid.jsx
+++ b/frontend/src/components/ProductsGrid/ProductsGrid.jsx
@@ -55,6 +55,21 @@ const ProductsGrid = (consts) => {
         }
     }
 
+    const transformTypeName = (elementType) => {
+        switch (elementType) {
+            case 'D':
+                return 'Diseños';
+            case 'I':
+                return 'Piezas';
+            case 'P':
+                return 'Impresoras';
+            case 'M':
+                return 'Materiales';
+            default:
+                return 'Productos';
+        }
+    }
+
     const [products, setProducts] = useState([]);
 
     useEffect(() => {
@@ -80,7 +95,7 @@ const ProductsGrid = (consts) => {
         <div className={getGridClass()}>
             {gridType === GRID_TYPES.UNLIMITED ? (
                 <>
-                    <Text type={TEXT_TYPES.TITLE_BOLD} text='Diseños' />
+                    <Text type={TEXT_TYPES.TITLE_BOLD} text={transformTypeName(elementType)} />
                     <div className='products-container'>
                         {products.map((group, groupIndex) => (
                             <div key={groupIndex} className={`products-row ${group.length < 5 ? 'last' : ''}`}>

--- a/frontend/src/pages/ArtistsPage.jsx
+++ b/frontend/src/pages/ArtistsPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ArtistsGrid, { GRID_TYPES } from '../components/ArtistsGrid/ArtistsGrid'
+
+const ArtistsPage = () => {
+  return (
+    <div>
+      <ArtistsGrid gridType={GRID_TYPES.UNLIMITED} />
+    </div>
+  )
+}
+
+export default ArtistsPage

--- a/frontend/src/pages/DesignsPage.jsx
+++ b/frontend/src/pages/DesignsPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ProductsGrid, { ELEMENT_TYPES, GRID_TYPES } from '../components/ProductsGrid/ProductsGrid'
+
+const DesignsPage = () => {
+  return (
+    <div>
+      <ProductsGrid gridType={GRID_TYPES.UNLIMITED} elementType={ELEMENT_TYPES.DESIGN} />
+    </div>
+  )
+}
+
+export default DesignsPage

--- a/frontend/src/pages/MaterialsPage.jsx
+++ b/frontend/src/pages/MaterialsPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ProductsGrid, { ELEMENT_TYPES, GRID_TYPES } from '../components/ProductsGrid/ProductsGrid'
+
+const MaterialsPage = () => {
+  return (
+    <div>
+      <ProductsGrid gridType={GRID_TYPES.UNLIMITED} elementType={ELEMENT_TYPES.MATERIAL} />
+    </div>
+  )
+}
+
+export default MaterialsPage

--- a/frontend/src/pages/PiecesPage.jsx
+++ b/frontend/src/pages/PiecesPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ProductsGrid, { ELEMENT_TYPES, GRID_TYPES } from '../components/ProductsGrid/ProductsGrid'
+
+const PiecesPage = () => {
+  return (
+    <div>
+      <ProductsGrid gridType={GRID_TYPES.UNLIMITED} elementType={ELEMENT_TYPES.IMPRESSION} />
+    </div>
+  )
+}
+
+export default PiecesPage

--- a/frontend/src/pages/PrintersPage.jsx
+++ b/frontend/src/pages/PrintersPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ProductsGrid, { ELEMENT_TYPES, GRID_TYPES } from '../components/ProductsGrid/ProductsGrid'
+
+const PrintersPage = () => {
+  return (
+    <div>
+      <ProductsGrid gridType={GRID_TYPES.UNLIMITED} elementType={ELEMENT_TYPES.PRINTER} />
+    </div>
+  )
+}
+
+export default PrintersPage


### PR DESCRIPTION
## Listados de productos y artistas #175

### Descripción

Se ha creado las páginas de diseños, piezas, impresoras, materiales y artistas. Además, se ha desarrollado la opción "UNLIMITED" en los listados de productos y de artistas, mediante la cual se podrán representar todos los productos de un determinado tipo, o todos los artistas en una página.

### Contexto Adicional

A continuación podemos ver las imágenes de las páginas desarrolladas:

![diseños](https://github.com/G12-ISPP/ISPP/assets/73230994/b6194674-2163-4058-8918-96a61942cf08)
![piezas](https://github.com/G12-ISPP/ISPP/assets/73230994/f1e3fc54-0b9f-4572-8614-80d46d0f7d46)
![impresoras](https://github.com/G12-ISPP/ISPP/assets/73230994/5b9a76f4-289d-4df9-9463-5f3f4cfe3f1e)
![materiales](https://github.com/G12-ISPP/ISPP/assets/73230994/4451a44a-a8dc-4624-b1c8-aa4c2f8f50cc)
![artistas](https://github.com/G12-ISPP/ISPP/assets/73230994/ed2c922c-ffa8-4fcb-8b39-3516a8de8bbb)

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [ ] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.