### PR TITLE
test: test sobre listado de productos

### DIFF
--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -6,10 +6,45 @@ from django.contrib.auth import get_user_model
 from .models import Product
 from .views import add_product
 from users.models import CustomUser
-
+from rest_framework.test import APIClient
 
 # Create your tests here.
 class ProductsViewTestClase(TestCase):
+    def setUp(self):
+        # Creamos algunos usuarios y productos para usar en los tests
+        self.user1 = CustomUser.objects.create(
+            username='user1',
+            password='test',
+            address='test',
+            postal_code=1234,
+            city='test'
+        )
+        self.user2 = CustomUser.objects.create(
+            username='user2',
+            password='test',
+            address='test',
+            postal_code=1234,
+            city='test'
+        )
+
+        # Creamos algunos productos
+        self.product1 = Product.objects.create(
+            product_type='I',
+            price=100,
+            name='Producto 1',
+            description='Descripción del producto 1',
+            stock_quantity=10,
+            seller=self.user1,
+        )
+        self.product2 = Product.objects.create(
+            product_type='P',
+            price=200,
+            name='Producto 2',
+            description='Descripción del producto 2',
+            stock_quantity=5,
+            seller=self.user2,
+        )
+        
     def test_get_product_data(self):
         customUser = CustomUser.objects.create(
             username='test',
@@ -39,3 +74,37 @@ class ProductsViewTestClase(TestCase):
         response = self.client.get('/products/api/v1/products/?product_type=I')
         self.assertEqual(response.status_code, 200)
         
+    def test_get_all_products(self):
+        client = APIClient()
+        response = client.get(reverse('products-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)  
+
+    def test_filter_by_product_type(self):
+        client = APIClient()
+        response = client.get(reverse('products-list') + '?product_type=I')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1) 
+        self.assertEqual(response.data[0]['id'], self.product1.id)
+
+    def test_filter_by_seller(self):
+        client = APIClient()
+        response = client.get(reverse('products-list') + f'?seller={self.user2.id}')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)  
+        self.assertEqual(response.data[0]['id'], self.product2.id)
+
+    def test_search_by_name_or_description(self):
+        client = APIClient()
+        response = client.get(reverse('products-list') + '?search=Producto 1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1) 
+        self.assertEqual(response.data[0]['id'], self.product1.id)
+
+    def test_combined_filters(self):
+        # Probamos combinar múltiples filtros
+        client = APIClient()
+        response = client.get(reverse('products-list') + '?product_type=P&search=Producto 2')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1) 
+        self.assertEqual(response.data[0]['id'], self.product2.id)

--- a/frontend/src/tests/LisProducts.test.jsx
+++ b/frontend/src/tests/LisProducts.test.jsx
@@ -1,0 +1,64 @@
+import { test } from 'vitest'
+import { render, screen } from "@testing-library/react";
+import DesignsPage from '../pages/DesignsPage'
+import PiecesPage from '../pages/PiecesPage'
+import PrintersPage from '../pages/PrintersPage'
+import MaterialsPage from '../pages/MaterialsPage'
+import ArtistsPage from '../pages/ArtistsPage'
+import '@testing-library/jest-dom'
+
+test('renderiza DesignsPage sin crashear', () => {
+    render(<DesignsPage />)
+  })
+
+
+test('renderiza PiecesPage sin crashear', () => {
+    render(<PiecesPage />)
+  })
+
+test('renderiza PrintersPage sin crashear', () => {
+    render(<PrintersPage />)
+  })
+
+test('renderiza MaterialsPage sin crashear', () => {
+    render(<MaterialsPage />)
+  })
+
+test('renderiza ArtistsPage sin crashear', () => {
+    render(<ArtistsPage />)
+  })
+
+test('DesignsPage contiene todos los objetos', () => {
+    render(<DesignsPage />)
+    
+    expect(screen.getByText('Diseños')).toBeInTheDocument()
+  
+  })
+
+test('Pieces contiene todos los objetos', () => {
+    render(<PiecesPage />)
+    
+    expect(screen.getByText('Piezas')).toBeInTheDocument()
+  
+  })
+
+test('Printers contiene todos los objetos', () => {
+    render(<PrintersPage />)
+    
+    expect(screen.getByText('Impresoras')).toBeInTheDocument()
+  
+  })
+
+test('Materials contiene todos los objetos', () => {
+    render(<MaterialsPage />)
+    
+    expect(screen.getByText('Materiales')).toBeInTheDocument()
+  
+  })
+
+test('Artists contiene todos los objetos', () => {
+    render(<ArtistsPage />)
+    
+    expect(screen.getByText('Artistas')).toBeInTheDocument()
+  
+  })


### PR DESCRIPTION
## Test sobre el listado de productos #203

### Descripción

Tests sobre todas las páginas de listado 

### Contexto Adicional

No se puede comprobar que hay objetos dentro ya que vitest no renderiza la página entera, es decir si pones un productsGrid eso no se verá en el html que renderiza vitest, por lo tanto no puedo ver cuantos objetos hay dentro de la página ni nada.

Tampco tiene sentido probar en el backend ya que estas vistas solo llaman a la api y las rutas están predefinidas, es decir nadie ha creado una url y vista específico viene todo dado por la api rest de django.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [x] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.
