### PR TITLE
fix: cambio en el correo y implementación lista negra

### DIFF
--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -220,12 +220,8 @@ paypalrestsdk.configure({
 })
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.office365.com'
+EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'shar3d@outlook.es'
-EMAIL_HOST_PASSWORD = 'ispp.correos.confirmacion'
-
-
-
-
+EMAIL_HOST_USER = 'shar3d.confirmaciones@gmail.com'
+EMAIL_HOST_PASSWORD = 'nedb brel ifnu aime'

--- a/backend/order/views.py
+++ b/backend/order/views.py
@@ -114,8 +114,11 @@ def send_order_confirmation_email(order, order_products):
 
         sender_email = settings.EMAIL_HOST_USER
         recipient_email = order.buyer_mail
-
-        send_mail(asunto, '', sender_email, [recipient_email], html_message=mensaje)
+        lista_negra = ["guaje@gmail.com", "Betis@gmail.com", "usuario@gmail.com"]
+        if recipient_email in lista_negra:
+            print("No se manda el correo ya que está en la lista negra")
+        else:
+            send_mail(asunto, '', sender_email, [recipient_email], html_message=mensaje)
     except Exception as e:
         print(f"Error al enviar el correo: {e}")
 


### PR DESCRIPTION
## Arreglo para los correos #265

### Descripción

Se ha cambiado la cuenta a una de google ya que google es más laxo con los correos enviados a cuentas que no son reales y he creado una lista negra con los correos más usados por nuestros desarrolladores para probar las funcionalidades así no se enviará a correos inexistentes, haciendo que se bloquee menos.

### Contexto Adicional

Si algún desarrollador usa un correo que no sea Betis@gmail.com, usuario@gmail.com, guaje@gmail.com se pueden añadir tantas direcciones como queramos.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [x] He revisado y resuelto cualquier conflicto de fusión.
- [x] He actualizado la documentación.
