### PR TITLE
Corregidas las mejoras id-8 e id-9

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -128,6 +128,9 @@ class UserCreateAPIView(generics.CreateAPIView):
         try:
             user_json = super().post(request, *args, **kwargs)
             user = CustomUser.objects.get(username=request.data.get('username'))
+            user.followings.add(user)
+            user.followers.add(user)
+            user.save()
 
 
             # Generar el token único

--- a/frontend/src/components/CustomDesign.jsx
+++ b/frontend/src/components/CustomDesign.jsx
@@ -240,8 +240,11 @@ export default class CustomModel extends React.Component {
     if (!file) {
       this.state.errors.file = 'Debes subir un archivo';
     }
-    if (name === '' || name.length >255) {
-      this.state.errors.name = 'Debes introducir un nombre de menos de 255 caracteres';
+    if(!name.trim()){
+      this.state.errors.name = 'Debes introducir un nombre';
+    }
+    if (name.trim().length <3 || name.length >50) {
+      this.state.errors.name = 'Debes introducir un nombre de entre 3 y 50 caracteres';
     }
     if(quantity < 1 || quantity > 100 || quantity!=Math.round(quantity)){
       this.state.errors.quantity = 'La cantidad debe ser un número entre 1 y 100';
@@ -441,9 +444,9 @@ export default class CustomModel extends React.Component {
             </div>
             <div className='form-group'>
               <label className='color'>Color*:</label>
-              <input type='button' id='Rojo' name='color'  className={`${this.state.color === 'Rojo' ? 'selected' : 'fat-btn'}`} value='Rojo' onClick={() => this.handleColor('red')} />
-              <input type='button' id='Azul' name='color' className={`${this.state.color === 'Azul' ? 'selected' : 'fat-btn'}`} value='Azul' onClick={() => this.handleColor('skyblue')} />
-              <input type='button' id='Verde' name='color' className={`${this.state.color === 'Verde' ? 'selected' : 'fat-btn'}`} value='Verde' onClick={() => this.handleColor('green')} />
+              <input type='button' id='Rojo' name='color'  className={`${this.state.color === 'red' ? 'selected' : 'fat-btn'}`} value='Rojo' onClick={() => this.handleColor('red')} />
+              <input type='button' id='Azul' name='color' className={`${this.state.color === 'skyblue' ? 'selected' : 'fat-btn'}`} value='Azul' onClick={() => this.handleColor('skyblue')} />
+              <input type='button' id='Verde' name='color' className={`${this.state.color === 'green' ? 'selected' : 'fat-btn'}`} value='Verde' onClick={() => this.handleColor('green')} />
             </div>
             <div className='form-group'>
               <label className='postal_code'>Código Postal*:</label>

--- a/frontend/src/components/RegisterForm/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm/RegisterForm.jsx
@@ -182,7 +182,7 @@ class RegisterForm extends React.Component {
               </div>
               <div className='register-form-row'>
                 <div className='register-form-group left'>
-                  <input type='text' id='postal_code' name='postal_code' className='form-input' placeholder='Código postal*' value={this.state.postal_code} onChange={this.handleChange} required />
+                  <input type='text' id='postal_code' name='postal_code' className='form-input' placeholder='CP*' value={this.state.postal_code} onChange={this.handleChange} required />
                 </div>
                 <div className='register-form-group right'>
                   <input type='text' id='city' name='city' className='form-input' placeholder='Ciudad*' value={this.state.city} onChange={this.handleChange} required />


### PR DESCRIPTION
Mejoras UP S3-2 #362 

### Descripción
Se han tratado las siguientes mejoras propuestas de los usuarios piloto
- id-8 Ahora al subir un post se nos redirecciona al feed y podemos ver nuestros post en el feed
- id-9 Ahora el nombre en los diseños no permitirá enviar solo espacios
- id-10 La funcionalidad seguirá, simplemente al desplegar intentaremos que la plataforma donde está esta función responda un poco más rápido, de todas formas se ha añadido una alerta indicando que el proceso puede durar entre 3 y cinco minutos aunque suele durar menos, entre 1 y 2
- id-11 Realmente este fallo no existe, el plan comprador no permite destacar productos y si solo te permiten destacar tres productos es porque solo tienes el plan diseñador
- id-12 Se ha probado y tanto con el plan comprador como con el plan diseñador si estamos en el límite de productos destacados y editamos un producto que ya estaba destacado podremos seguir destacandolo sin problemas. Sin embargo, como se espera, si ya estás en el límite e intentas destacar un producto más, no te dejara para que no superes el límite


### Contexto Adicional

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [ ] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.
