### PR TITLE
Test 213 plan comprador

### DIFF
--- a/backend/order/views.py
+++ b/backend/order/views.py
@@ -64,7 +64,9 @@ def create_order(request):
         except Product.DoesNotExist:
             return JsonResponse({'error': 'El producto con ID {} no existe'.format(product_id)}, status=400)
         price += product.price * quantity
-    buyerPlan = order.buyer
+    buyername = order.buyer
+    buyer = CustomUser.objects.get(username=buyername)
+    buyerPlan = buyer.buyer_plan
     if envio and not(buyerPlan):
         price += 5
     order.price = price


### PR DESCRIPTION
## Test Plan comprador #213 

### Descripción

Si se intentaba comprar sin plan comprador, los gastos de envío aparecían en el carrito, pero no se cobraban. Esto ahora se ha arreglado y se ha testeado.

### Contexto Adicional

Incluye cualquier contexto relevante o información adicional sobre la solicitud de extracción.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [ ] He probado exhaustivamente estos cambios localmente.
- [ ] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.
