### PR TITLE
Error: Seguimiento de pedido corregido y vaciar mensaje chat tras enviar 

### DIFF
--- a/backend/order/views.py
+++ b/backend/order/views.py
@@ -194,6 +194,10 @@ def mark_products_as_sent(request, token):
 
     # Asumiendo que usas el primer enfoque y que el token está asociado a un vendedor
     OrderProduct.objects.filter(order=action_token.order, product__seller=action_token.seller).update(state='Enviado')
+    order = Order.objects.get(id=action_token.order.id)
+    order.status = 'E'
+    order.save()
+
     return HttpResponse('Productos marcados como enviados. Puedes cerrar la pestaña.')
 
 def cancel_order(request, order_id):

--- a/frontend/src/components/Chat/ChatComponent.jsx
+++ b/frontend/src/components/Chat/ChatComponent.jsx
@@ -78,6 +78,7 @@ const ChatComponent = ({ roomId, roomName, roomMate }) => {
       setTimeout(fetchMessages, 200);
       setTimeout(() => {
         scrollToBottom();
+        setNewMessage('');
       }, 250); // Ajusta este tiempo si es necesario
     })
     .catch(error => {


### PR DESCRIPTION
## Seguimiento pedido y vaciar mensaje chat al enviar #461 

### Descripción

Se ha solucionado un problema al marcar los productos como enviados, donde solo se marcaban los productos y no el pedido.

### Contexto Adicional

 También se ha encontrado otro error a la hora de enviar un mensaje por chat. Cuando se envía cualquier mensaje, el campo de texto no se vaciaba, provocando que se tuviera que borrar todo para enviar un mensaje nuevo.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] He probado exhaustivamente estos cambios localmente.
- [x] He revisado y resuelto cualquier conflicto de fusión.
- [ ] He actualizado la documentación.
